### PR TITLE
fix: auto-resolve Dependabot alerts (20260623)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7742,15 +7742,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.12
-  resolution: "tar@npm:7.5.12"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/3825c5974f5fde792981f47ee9ffea021ee7f4b552b7ab95eeb98e5dfadfd5a5d5861f01fb772e2e5637a41980d3c019fd6cdad1be48b462b886abd7fe0fa17c
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
このPRは `resolve-dependabot` スキルが autonomous モードで自動生成しました。レビュー後にマージしてください。

## 解決対象アラート

- Dependabot PR #17: `tar` 7.5.12→7.5.16 [moderate]
  - 間接依存 (transitive) — `node-gyp` が `tar: "npm:^7.5.4"` で参照
  - semver range 参照のため `resolutions`/`overrides` 不要

## 変更内容

- **間接依存 refresh**: `tar` 7.5.12 → 7.5.16 (`yarn.lock` のみ)
- `package.json` への変更なし
- `resolutions`/`overrides` 例外: なし

## 検証結果

⚠️ **ローカル検証不可**: 実行環境がネットワーク制限下のためパッケージインストール不可 (`node_modules` なし)。`corepack yarn lint` / `corepack yarn build` を実行できませんでした。

- 変更内容は Dependabot PR #17 の diff と完全に一致しています (version + checksum のみ更新)
- **CI (このPRのチェック) が実質的な検証ゲートとなります。** CI グリーン確認後にマージしてください。

## 元の Dependabot PR との関係

このPRは Dependabot PR #17 を **supersede しません** (autonomous モードではDependabot PRのクローズは禁止)。マージ後、Dependabot PR #17 は conflict またはアラート解消により自動クローズされます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7RjfSyVF7EjurAwr7hHw5)_