### PR TITLE
fix: auto-resolve Dependabot alerts (20260726)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7742,15 +7742,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.12
-  resolution: "tar@npm:7.5.12"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/3825c5974f5fde792981f47ee9ffea021ee7f4b552b7ab95eeb98e5dfadfd5a5d5861f01fb772e2e5637a41980d3c019fd6cdad1be48b462b886abd7fe0fa17c
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
このPRは `resolve-dependabot` スキルが autonomous モードで自動生成しました。レビュー後にマージしてください。

## 解決対象アラート

- **PR #17**: `tar` 7.5.12 → 7.5.16 (npm_and_yarn group, moderate/high severity)

## 変更内容

- **間接依存 refresh**: `tar` — `node-gyp` が `^7.5.4` の semver range で参照しているため通常の transitive 更新
  - `version`: 7.5.12 → 7.5.16
  - `resolution`: `tar@npm:7.5.16`
  - `checksum`: 更新済み (Dependabot PR #17 の diff より verbatim 適用)
- `resolutions`/`overrides` は使用していません

## 適用方法の注記

このセッションの egress policy により npm/yarn レジストリ (`registry.yarnpkg.com`, `registry.npmjs.org`) へのアクセスがブロックされていたため、`yarn up -R tar` を直接実行できませんでした。代わりに Dependabot PR #17 の diff (checksum 含む) を yarn.lock に verbatim で適用しています。

## 検証結果

- `yarn lint` / `yarn build`: **未実行** — `node_modules` のインストールにレジストリアクセスが必要ですが、この実行環境ではブロックされています
- **CI による検証が必須です。CI グリーンを確認してからマージしてください。**

## 残存アラートについて

push 時に GitHub から「5 vulnerabilities (3 high, 2 moderate) on the default branch」の通知がありました。このPRで解決するのは tar の1件のみです。残り4件は Dependabot アラート API へのアクセス制限により、このセッションでは詳細を取得できませんでした。別途対応をご検討ください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCQE7upzdhHqWUYPM216Rx)_