### PR TITLE
fix: auto-resolve Dependabot alerts (20260731)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7742,15 +7742,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.12
-  resolution: "tar@npm:7.5.12"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/3825c5974f5fde792981f47ee9ffea021ee7f4b552b7ab95eeb98e5dfadfd5a5d5861f01fb772e2e5637a41980d3c019fd6cdad1be48b462b886abd7fe0fa17c
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
このPRは `resolve-dependabot` スキルが autonomous モードで自動生成しました。レビュー後にマージしてください。

## 解決対象アラート

- #17 (Dependabot PR): `tar` 7.5.12 → 7.5.16 [security]
  - 間接依存 (`node-gyp@latest` → `tar: "npm:^7.5.4"` の semver range で参照)
  - lockfile refresh で対応 (resolutions/overrides は不使用)
  - checksum は Dependabot PR #17 のdiffから検証済み

## 変更内容

- **間接依存 refresh**: `tar` 7.5.12 → 7.5.16 (yarn.lock のみ変更、package.json 変更なし)
- `resolutions`/`overrides` 例外: **なし** (semver range `^7.5.4` のため通常 refresh で解決)

## 検証結果

⚠️ **lint/build 未実行**: 実行環境が network-isolated で `node_modules` をインストールできなかったため、`next lint` / `next build` をスキップしました。
- 変更は yarn.lock のみ (コード変更なし)
- checksum は GitHub Dependabot PR #17 の diff から直接取得し、内容一致を確認済み
- マージ前に手動で `yarn install && yarn lint && yarn build` による検証を推奨します

## 補足

- push 時のメッセージに「28 vulnerabilities」の記載あり。本PRで対応できるのは `tar` (Dependabot PR #17) のみです。残りのアラートは Dependabot alerts API へのアクセスが blocked されたため詳細不明。別途 Security タブで確認・対応をお願いします。

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RYKgcpipNtceZZH9wAiE)_